### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/Schmakus/ioBroker.lightcontrol.git"
   },
   "engines": {
-    "node": ">= 16",
+    "node": ">= 18",
     "npm": ">=7"
   },
   "dependencies": {


### PR DESCRIPTION
As you removed node 16 tests this adapter requires node 18 minimum.

Please check and merge PR.